### PR TITLE
Update terraform docker image to 0.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.11.1
+FROM hashicorp/terraform:0.11.2
 MAINTAINER Kazumichi Yamamoto <yamamoto.febc@gmail.com>
 
 LABEL io.whalebrew.config.environment '["SAKURACLOUD_ACCESS_TOKEN", "SAKURACLOUD_ACCESS_TOKEN_SECRET" , "SAKURACLOUD_ZONE" , "SAKURACLOUD_TIMEOUT" , "SAKURACLOUD_TRACE_MODE","SACLOUD_OJS_ACCESS_KEY_ID","SACLOUD_OJS_SECRET_ACCESS_KEY" ]'


### PR DESCRIPTION
(PR出してよいのかな… 作業予定ありなら素直に閉じちゃってください)

terraform本体の[versionがあがってます](https://github.com/hashicorp/terraform/blob/v0.11.2/CHANGELOG.md#0112-january-9-2018)。

ここのDockerfileをcircleciで使ってるので、あげてくれると助かりますー 😸 
(でもsakura側のバージョンが上がらないのでちょっと難しいかな…)

